### PR TITLE
Change sync cron schedule from daily 6:00 to mondays 06:00

### DIFF
--- a/.github/workflows/sync-aerodromes.yml
+++ b/.github/workflows/sync-aerodromes.yml
@@ -2,9 +2,8 @@ name: Sync Aerodromes
 
 on:
   schedule:
-    # Run daily at 6:00 AM UTC during initial validation phase
-    # Change back to '0 6 * * 1' (Monday only) once system is stable
-    - cron: '0 6 * * *'
+    # Run mondays at 6:00 AM UTC
+    - cron: '0 6 * * 1'
   
   # Allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
Once a week is often enough for this cron job (we can always also trigger it manually on GitHub when a sync is needed urgently at some point)